### PR TITLE
Add required dev dep for "dev" package/json script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "devDependencies": {
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
-    "prettier": "2.7.1"
+    "prettier": "2.7.1",
+    "nodemon": "2.0.20"
   },
   "prettier": {
     "tabWidth": 4,


### PR DESCRIPTION
Alternatively, it might be expected to install `nodemon` globally - I'd suggest documenting this requirement in `tablane/tablane`'s README if so.